### PR TITLE
ajout de la carte pour géolocaliser les villes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "jsonfile": "2.0.1",
     "moment": "^2.10.3",
     "react": "0.13.3",
+    "react-tabs": "0.2.0",
+    "react-google-maps":"1.3.1",
     "react-bootstrap": "0.22.6",
     "react-router": "0.13.3",
     "react-tap-event-plugin": "0.1.7",

--- a/src/main/resources/app/_js/components/home.js
+++ b/src/main/resources/app/_js/components/home.js
@@ -3,6 +3,13 @@ var Router = require('react-router');
 var ReactBootstrap = require('react-bootstrap');
 var $ = require('jquery');
 
+var ReactTabs = require('react-tabs');
+var Tab = ReactTabs.Tab;
+var Tabs = ReactTabs.Tabs;
+var TabList = ReactTabs.TabList;
+var TabPanel = ReactTabs.TabPanel;
+
+var CityMap = require('./map');
 var CityLinkList = require('./city-link-list');
 var GoogleCalendar = require('./social/google-calendar');
 var TwitterTimeline = require('./social/twitter-timeline');
@@ -41,7 +48,26 @@ var Home = React.createClass({
                     Recherche
                 </Link>
 
-                <CityLinkList cities={this.state.cities}/>
+                <Tabs
+                onSelect={this.handleSelected}
+                selectedIndex={1}
+                >
+
+                    <TabList>
+                        <Tab>La liste</Tab>
+                        <Tab>La carte</Tab>
+
+                    </TabList>
+
+
+                    <TabPanel>
+                        <CityLinkList cities={this.state.cities}/>
+                    </TabPanel>
+                    <TabPanel>
+                        <CityMap cities={this.state.cities}/>
+                    </TabPanel>
+
+                </Tabs>
 
                 <Grid>
                     <Row>

--- a/src/main/resources/app/_js/components/map.js
+++ b/src/main/resources/app/_js/components/map.js
@@ -1,0 +1,137 @@
+var React = require('react');
+var Router = require('react-router');
+var $ = require('jquery');
+
+var GGMaps = require('react-google-maps');
+var GoogleMaps = GGMaps.GoogleMaps;
+var Circle = GGMaps.Circle;
+var Marker = GGMaps.Marker;
+var InfoBox = GGMaps.InfoBox;
+
+var EventAnchorList = require('./event-anchor-list');
+var EventList = require('./event-list');
+
+var DevConferencesClient = require('../client/client');
+
+var CityMap = React.createClass({
+
+    mixins: [Router.Navigation],
+
+    getInitialState: function () {
+
+        return {
+            cities: [],
+            citiesLoaded: false,
+            browserLocation: {
+                lat: 46.5,
+                lng: 1
+            },
+            zoom: 6
+        };
+    },
+
+    componentDidMount: function() {
+        var geocoder = new google.maps.Geocoder();
+        var that = this;
+        var citiesFromCache = localStorage.getItem("devconferences-cities");
+        if (citiesFromCache) {
+            this.setState({
+               citiesLoaded: true,
+               cities: JSON.parse(citiesFromCache)
+            });
+        } else {
+
+            DevConferencesClient.cities().then(function(resp) {
+                var cities = resp.data;
+                var finalCities = [];
+                function codeAddress() {
+                    if (cities.length === 0) {
+                        localStorage.setItem("devconferences-cities", JSON.stringify(finalCities));
+                        that.setState({
+                            citiesLoaded: true,
+                            cities: finalCities
+                        });
+                    } else {
+                        var city = cities.pop();
+                        if (!city.position) {
+                            console.debug("Je cherche l'adresse de la ville " + city.name);
+                            geocoder.geocode({ 'address': city.name}, function (results, status) {
+                                if (status == google.maps.GeocoderStatus.OK) {
+                                    console.debug("found ville " + city.name);
+                                    city.position = {"lat":results[0].geometry.location.A, "lng":results[0].geometry.location.F};
+
+                                    finalCities.push(city);
+                                } else {
+                                    console.debug('Geocode was not successful for the following reason: ' + status);
+                                }
+                                that.setState({
+                                    cities: finalCities
+                                });
+                                setTimeout(codeAddress, 1000);
+                            });
+                        }
+                    }
+                }
+                codeAddress();
+            });
+        }
+
+    },
+
+    position : function(position){
+        this.setState({
+            browserLocation: {
+                lat: position.coords.latitude,
+                lng: position.coords.longitude
+            },
+            zoom: 8
+        });
+    },
+
+    render: function () {
+
+        if(this.state.citiesLoaded && navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(this.position);
+        }
+        if(this.state.browserLocation) {
+            return (
+                <div>
+                    <GoogleMaps containerProps={{
+                        style: {
+                            height: "500px",
+                            width: "80%"
+                        }
+                    }}
+                    googleMapsApi={
+                            "undefined" !== typeof google ? google.maps : null
+                        }
+                    zoom={this.state.zoom}
+                    center={{lat: this.state.browserLocation.lat, lng: this.state.browserLocation.lng}}
+                    >
+                     {this.state.cities.map(toMarker, this)}
+                    </GoogleMaps>
+
+                </div>
+                );
+            function toMarker (city, index) {
+                if(city.count>1) {
+                    return (
+                        <Circle center={city.position} radius={2000 * city.count} fillColor="red" fillOpacity={0.20} strokeColor="red" strokeOpacity={1} strokeWeight={1} />
+                        );
+                }else{
+                    return ( <Marker position={city.position} key={city.name}/>);
+                }
+            }
+
+        }else{
+            return(<div>en chargement</div>)
+        }
+    }
+});
+
+/* <InfoBox
+ closeBoxURL=""
+ position={city.position}
+ content={city.name+' '+city.count} /> */
+
+module.exports = CityMap;

--- a/src/main/resources/app/index.html
+++ b/src/main/resources/app/index.html
@@ -32,7 +32,7 @@
 </head>
 
 <body>
-
+<script src="http://maps.googleapis.com/maps/api/js"></script>
 <script src="/js/bundle.js"></script>
 
 </body>


### PR DESCRIPTION
La liste des villes est géolocalisée si besoin, dans ce cas il y a un timeout assez long pour ne pas être gêné par les quotas de Google Maps.

La liste est stockée en LocalStorage (à améliorer pour gérer une expiration).

Un marker (marker simple si une seule conf et cercle de taille variable si plusieurs confs) est déposé sur chaque ville et la carte est centrée sur la géolocalisation du navigateur en fin de géolocalisation des villes (le centrage et zoom ne sont pas fait avant pour laisser voir les markers apparaitre sur les autres villes).

Il faudrait ajouter un panel "loading" mais je ne savais pas vraiment comment faire. (A discuter)
