### PR TITLE
Utilisation d'un DevConferencesClient pour les recherches

### DIFF
--- a/src/main/resources/app/_js/components/search.js
+++ b/src/main/resources/app/_js/components/search.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var $ = require('jquery');
 var Event = require('./event');
+var DevConferencesClient = require('../client/client');
 
 var Search = React.createClass({
 
@@ -15,21 +16,9 @@ var Search = React.createClass({
     },
 
     changeInput: function (e) {
-
         var searchValue = this.refs.searchInput.getDOMNode().value;
-        var url = "http://devconferences.cleverapps.io/api/v2/events/search?q=" + searchValue;
 
-        $.ajax({
-            url: url,
-            dataType: 'json',
-            cache: false,
-            success: function(data) {
-                this.setState({items: data});
-            }.bind(this),
-            error: function(xhr, status, err) {
-                console.error(url, status, err.toString());
-            }.bind(this)
-        });
+        DevConferencesClient.searchEvents(searchValue).then(items => this.setState({items: items.data}));
     },
 
     render: function () {


### PR DESCRIPTION
La recherche d'événements appelait l'API sur cleverapps.io, que ce soit en _prod mode_ ou en _dev mode_. En passant par le client, cela permet d'effectuer un requête en localhost en _dev mode_, en plus de limiter les appels directs à l'API.

Il y a juste au niveau de la gestion des erreurs que je ne sais pas si le comportement est bon.
